### PR TITLE
Update javax.xml.bind:jaxb-api to jakarta.xml.bind:jakarta.xml.bind-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.immregistries</groupId>
 	<artifactId>codebase-client</artifactId>
-	<version>2.3.1</version>
+	<version>3.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>Client Jar for using the Codebase</name>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-   		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+   		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -67,9 +67,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.1</version>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>4.0.2</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/immregistries/codebase/client/CodeMapBuilder.java
+++ b/src/main/java/org/immregistries/codebase/client/CodeMapBuilder.java
@@ -5,12 +5,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import org.immregistries.codebase.client.generated.Codebase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
 public enum CodeMapBuilder {
   INSTANCE;

--- a/src/main/java/org/immregistries/codebase/client/generated/Code.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/Code.java
@@ -8,11 +8,10 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.

--- a/src/main/java/org/immregistries/codebase/client/generated/CodeStatus.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/CodeStatus.java
@@ -8,11 +8,10 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.

--- a/src/main/java/org/immregistries/codebase/client/generated/Codebase.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/Codebase.java
@@ -10,10 +10,10 @@ package org.immregistries.codebase.client.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/src/main/java/org/immregistries/codebase/client/generated/Codeset.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/Codeset.java
@@ -10,10 +10,10 @@ package org.immregistries.codebase.client.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/src/main/java/org/immregistries/codebase/client/generated/Deprecated.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/Deprecated.java
@@ -8,11 +8,10 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.

--- a/src/main/java/org/immregistries/codebase/client/generated/LinkTo.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/LinkTo.java
@@ -8,12 +8,11 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 /**
  * <p>Java class for anonymous complex type.

--- a/src/main/java/org/immregistries/codebase/client/generated/ObjectFactory.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/ObjectFactory.java
@@ -8,8 +8,7 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
+import jakarta.xml.bind.annotation.XmlRegistry;
 
 /**
  * This object contains factory methods for each 

--- a/src/main/java/org/immregistries/codebase/client/generated/Reference.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/Reference.java
@@ -10,10 +10,10 @@ package org.immregistries.codebase.client.generated;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 
 /**

--- a/src/main/java/org/immregistries/codebase/client/generated/UseAge.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/UseAge.java
@@ -8,11 +8,10 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.

--- a/src/main/java/org/immregistries/codebase/client/generated/UseDate.java
+++ b/src/main/java/org/immregistries/codebase/client/generated/UseDate.java
@@ -8,11 +8,10 @@
 
 package org.immregistries.codebase.client.generated;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for anonymous complex type.


### PR DESCRIPTION
I really have no idea how to test this other than it gets me past this exception I was getting before:

```
java.lang.RuntimeException: Could not marshall the codemap
	at org.immregistries.codebase.client.CodeMapBuilder.getCodeMap(CodeMapBuilder.java:40)
	at org.immregistries.aart.logic.CodeManager.getCodeMap(CodeManager.java:24)
	at org.immregistries.aart.logic.TestMessageDataReturnedLogic.initAliasMap(TestMessageDataReturnedLogic.java:57)
	at org.immregistries.aart.logic.TestMessageDataReturnedLogic.queryReturnedMostImportantData(TestMessageDataReturnedLogic.java:101)
	at org.immregistries.aart.servlet.DiscoveryContentServlet.printTestMessage(DiscoveryContentServlet.java:1220)
	at org.immregistries.aart.servlet.ServletSupport.printTestMessageDetails(ServletSupport.java:61)
	at org.immregistries.aart.servlet.fits.FitsMartRunServlet.getFitsTestDetailsHTML(FitsMartRunServlet.java:835)
	at org.immregistries.aart.servlet.fits.FitsMartRunServlet.handleActions(FitsMartRunServlet.java:348)
	at org.immregistries.aart.servlet.fits.FitsMartRunServlet.doGet(FitsMartRunServlet.java:272)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.immregistries.aart.servlet.filter.AuthenticationFilter.doFilter(AuthenticationFilter.java:47)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:483)
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:663)
	at org.apache.catalina.valves.rewrite.RewriteValve.invoke(RewriteValve.java:543)
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:384)
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:904)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190)
	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: javax.xml.bind.JAXBException: Implementation of JAXB-API has not been found on module path or classpath.
 - with linked exception:
[java.lang.ClassNotFoundException: com.sun.xml.internal.bind.v2.ContextFactory]
	at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:278)
	at javax.xml.bind.ContextFinder.find(ContextFinder.java:421)
	at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:721)
	at javax.xml.bind.JAXBContext.newInstance(JAXBContext.java:662)
	at org.immregistries.codebase.client.CodeMapBuilder.getCodeMap(CodeMapBuilder.java:33)
	... 36 more
Caused by: java.lang.ClassNotFoundException: com.sun.xml.internal.bind.v2.ContextFactory
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1332)
	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1144)
	at javax.xml.bind.ServiceLoaderUtil.nullSafeLoadClass(ServiceLoaderUtil.java:122)
	at javax.xml.bind.ServiceLoaderUtil.safeLoadClass(ServiceLoaderUtil.java:155)
	at javax.xml.bind.ContextFinder.newInstance(ContextFinder.java:276)
	... 40 more
```